### PR TITLE
format, parse video sample description data

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2018"
+max_width = 160

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -11,9 +11,7 @@ pub struct Deserializer<R: Read> {
 
 impl<R: Read> Deserializer<R> {
     pub fn new(reader: R) -> Self {
-        Deserializer{
-            reader: reader,
-        }
+        Deserializer { reader: reader }
     }
 }
 
@@ -87,10 +85,7 @@ struct SeqAccess<'a, R: Read> {
 
 impl<'a, R: Read> SeqAccess<'a, R> {
     fn new(de: &'a mut Deserializer<R>, len: usize) -> Self {
-        SeqAccess {
-            de,
-            left: len,
-        }
+        SeqAccess { de, left: len }
     }
 }
 
@@ -98,7 +93,8 @@ impl<'de, 'a, R: Read> de::SeqAccess<'de> for SeqAccess<'a, R> {
     type Error = Error;
 
     fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>
-        where T: DeserializeSeed<'de>
+    where
+        T: DeserializeSeed<'de>,
     {
         if self.left > 0 {
             self.left -= 1;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 use std::io;
 
-use serde::ser::Error as SerdeSerError;
 use serde::de::Error as SerdeDeError;
+use serde::ser::Error as SerdeSerError;
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
-#[macro_use] extern crate serde;
-#[macro_use] extern crate serde_derive;
+#[macro_use]
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
 
 pub mod atom;
 pub mod data;

--- a/src/serializer.rs
+++ b/src/serializer.rs
@@ -11,9 +11,7 @@ pub struct Serializer<W: Write> {
 
 impl<W: Write> Serializer<W> {
     pub fn new(writer: W) -> Self {
-        Serializer{
-            writer: writer,
-        }
+        Serializer { writer: writer }
     }
 }
 


### PR DESCRIPTION
This adds decoding for video sample description data. This data contains H.264's SPS and PPS NALUs, which are required for decoding.

See the `test_video_sample_description_data_entry` test for example.

This also adds a rustfmt config. Going to comment on all the changes so it's clear where actual changes were made.